### PR TITLE
Initial sphinx docs setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ venv27
 .eggs
 
 indico_api_token.txt
+
+docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ venv27
 
 .eggs
 
+.idea
+
 indico_api_token.txt
 
 docs/_build

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: setuptools

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ import sys
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-sys.path.insert(0, os.path.abspath('../indicoio'))
+sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------
@@ -30,7 +30,8 @@ author = 'indico'
 # ones.
 extensions = [
     'sphinx_rtd_theme',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import sphinx_rtd_theme
+import os
+import sys
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+sys.path.insert(0, os.path.abspath('../indicoio'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'indicoio Python Client Library'
+copyright = '2020, indico'
+author = 'indico'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx_rtd_theme',
+    'sphinx.ext.autodoc'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,10 @@
+====================
+Client Configuration
+====================
+
+Getting Started
+---------------
+
+First, download an API token from your `user dashboard`_ and save the downloaded file as 'indico_api_token.txt' in either your home directory or working directory. 
+
+.. _user dashboard: https://app.indico.io/auth/user

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,26 @@
+.. indicoio Python Client Library documentation master file, created by
+   sphinx-quickstart on Wed Jan 29 10:52:07 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+indicoio Python Client Library
+==============================
+
+Client API
+----------
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Contents:
+
+    configuration
+    model_group
+    prebuilt
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/model_group.rst
+++ b/docs/model_group.rst
@@ -2,10 +2,10 @@
 Model Groups
 ================
 
-This is the object you will use for making predictions with indico models :class:`~api.indico.Indico`
+This is the object you will use for making predictions with indico models :class:`~indicoio.api.indico.Indico`
 
 indicoio.ModelGroup
 -------------------
 
-.. automodule:: api.model_group
+.. automodule:: indicoio.api.model_group
   :members:

--- a/docs/model_group.rst
+++ b/docs/model_group.rst
@@ -1,0 +1,11 @@
+================
+Model Groups
+================
+
+This is the object you will use for making predictions with indico models :class:`~api.indico.Indico`
+
+indicoio.ModelGroup
+-------------------
+
+.. automodule:: api.model_group
+  :members:

--- a/docs/prebuilt.rst
+++ b/docs/prebuilt.rst
@@ -2,10 +2,10 @@
 Indico Prebuilt API
 ===================
 
-For prebuilt Indico models use :class:`~api.prebuilt.IndicoApi`
+For prebuilt Indico models use :class:`~indicoio.api.prebuilt.IndicoApi`
 
 indicoio.IndicoApi
 ------------------
 
-.. automodule:: api.prebuilt
+.. automodule:: indicoio.api.prebuilt
   :members:

--- a/docs/prebuilt.rst
+++ b/docs/prebuilt.rst
@@ -1,0 +1,11 @@
+===================
+Indico Prebuilt API
+===================
+
+For prebuilt Indico models use :class:`~api.prebuilt.IndicoApi`
+
+indicoio.IndicoApi
+------------------
+
+.. automodule:: api.prebuilt
+  :members:

--- a/indicoio/api/model_group.py
+++ b/indicoio/api/model_group.py
@@ -11,7 +11,26 @@ from indicoio.errors import IndicoInputError
 
 
 class ModelGroup(ObjectProxy):
-    def predict(self, data, model_id=None, job_results=False, **predict_kwargs):
+    """
+    Model Group
+
+    Example::
+
+        mg = ModelGroup(id=<model group id>)
+        mg.load()
+        mg.predict(["some text"])
+
+    :param config_options: configureation options for the model group
+    """
+
+    def predict(self, data=None, job_results=False, **predict_kwargs):
+        """
+        Gets the model predictions for a list of inputs
+
+        :param data: List of inputs for predictions.
+        :param model_id: Specify the specific model to use for predition. If empty, the currently selected model within this group will be used
+        :param job_results: True to return the id of the prediction job rather than the prediction results directly.
+        """
         if not isinstance(data, list):
             raise IndicoInputError(
                 "This function expects a list input. If you have a single piece of data, please wrap it in a list"
@@ -38,6 +57,11 @@ class ModelGroup(ObjectProxy):
             return job.result()
 
     def load(self, model_id=None):
+        """
+        Loads the requested model into memory for predictions
+
+        :param model_id: Specify the specific model to use for predition. If empty, the most recently trained model will be used.
+        """
         if self.info().get("load_status") == "ready":
             return "ready"
 
@@ -61,6 +85,9 @@ class ModelGroup(ObjectProxy):
         return status
 
     def info(self):
+        """
+        Returns information about this model group.
+        """
         response = self.graphql.query(
             f"""query {{
                 modelGroups(modelGroupIds: [{self["id"]}]) {{
@@ -81,6 +108,9 @@ class ModelGroup(ObjectProxy):
         return {}
 
     def get_selected_model(self):
+        """
+        Returns the ID of the currently selected model within this group
+        """
         response = self.graphql.query(
             f"""query {{
                 modelGroups(modelGroupIds: [{self["id"]}]) {{
@@ -98,6 +128,9 @@ class ModelGroup(ObjectProxy):
         return self["selectedModel"]
 
     def refresh(self):
+        """
+        Refreshes something... unclear
+        """
         response = self.graphql.query(
             f"""query {{
                 modelGroups(modelGroupIds: [{self["id"]}]) {{

--- a/indicoio/api/prebuilt.py
+++ b/indicoio/api/prebuilt.py
@@ -8,20 +8,38 @@ from typing import List
 
 
 def _convert_options_to_str(options):
-        return ",".join(
-            f"{key}: {json.dumps(option)}"
-            for key, option in options.items()
-        )
+    return ",".join(
+        f"{key}: {json.dumps(option)}"
+        for key, option in options.items()
+    )
+
 
 class IndicoApi(Indico):
-    def pdf_extraction(self, data: List[str], job_results: bool=False, **pdf_extract_options):
+    """
+    IndicoApi
+
+    Example::
+
+        api_client = IndicoApi()
+        api_client.pdf_extraction(["url or file"], **options)
+
+    """
+
+    def pdf_extraction(self, data: List[str], job_results: bool = False, **pdf_extract_options):
+        """
+        Extracts and returns the contents of a PDF Document
+
+        :param data: List of inputs for extraction.
+        :param job_results: True to return the id of the prediction job rather than the prediction results directly.
+        :pdf_extract_options: Options to pass to PDF extraction
+        """
         if not isinstance(data, list):
             raise IndicoInputError(
                 "This function expects a list input. If you have a single piece of data, please wrap it in a list"
             )
         data = [pdf_preprocess(datum) for datum in data]
         data = json.dumps(data)
-        
+
         option_string = _convert_options_to_str(pdf_extract_options)
 
         response = self.graphql.query(
@@ -42,7 +60,14 @@ class IndicoApi(Indico):
             job.wait()
             return job.result()
 
-    def document_extraction(self, data: List[str], job_results: bool=False, **document_extraction_options):
+    def document_extraction(self, data: List[str], job_results: bool = False, **document_extraction_options):
+        """
+        Extracts and returns the contents of a Word Document
+
+        :param data: List of inputs for extraction.
+        :param job_results: True to return the id of the prediction job rather than the prediction results directly.
+        :document_extraction_options: Options to pass to Document extraction
+        """
         if not isinstance(data, list):
             raise IndicoInputError(
                 "This function expects a list input. If you have a single piece of data, please wrap it in a list"
@@ -50,8 +75,8 @@ class IndicoApi(Indico):
         data = [pdf_preprocess(datum) for datum in data]
         data = json.dumps(data)
 
-        option_string = _convert_options_to_str(options)
-        
+        option_string = _convert_options_to_str(document_extraction_options)
+
         response = self.graphql.query(
             f"""
             mutation {{


### PR DESCRIPTION
So probably don't merge this for now. But this sets up the initial sphinx setup for documenting the library.  To build the docs you'll need to:

```pip install sphinx sphinx_rtd_theme```

Then from the docs directory run ```make html```. When that builds ```open _build/html/index.html``` and you'll see the docs in the browser.  A lot of this pulls directly from the comments in the source files, so someone will need to make sure those are accurate and makes sense.