### PR TITLE
fix issue with setting api token path from environment variable

### DIFF
--- a/indicoio/config.py
+++ b/indicoio/config.py
@@ -10,10 +10,14 @@ api_token_path = os.getenv("INDICO_API_TOKEN_PATH")
 
 def resolve_api_token(path=None):
     path = path or api_token_path
-    if not path:
-        path = Path(".") / "indico_api_token.txt"
-        if not path.exists():
-            path = Path.home() / "indico_api_token.txt"
+    if path is None:
+        path = "."
+    if not isinstance(path, Path):
+        path = Path(path)
+    if not path.exists():
+        path = Path.home()
+    if not path.is_file():
+        path = path / "indico_api_token.txt"
 
     if not path.exists():
         raise RuntimeError(


### PR DESCRIPTION
convert API token path from environment variable string to Path object before checking whether the path exists.