### PR TITLE
handle storage in url

### DIFF
--- a/indicoio/api/prebuilt.py
+++ b/indicoio/api/prebuilt.py
@@ -101,7 +101,7 @@ class IndicoApi(Indico):
             extracted = []
             for job in jobs:
                 job.wait()
-                url = job.result()
+                url = job.result()["url"]
                 downloaded = self.storage.download(url)
                 extracted.append(downloaded)
             return extracted

--- a/indicoio/client/storage.py
+++ b/indicoio/client/storage.py
@@ -52,5 +52,5 @@ def _parse_uploaded_files(uploaded_files: List[dict]):
 
 def _resolve_indico_protocol(base_url, url):
     relative_url = "/".join(url.split("/")[3:])
-    full_url = f"{base_url}/api/storage/" + relative_url
+    full_url = f"{base_url}/api/" + relative_url
     return full_url

--- a/indicoio/client/storage.py
+++ b/indicoio/client/storage.py
@@ -52,5 +52,5 @@ def _parse_uploaded_files(uploaded_files: List[dict]):
 
 def _resolve_indico_protocol(base_url, url):
     relative_url = "/".join(url.split("/")[3:])
-    full_url = f"{base_url}/api/" + relative_url
+    full_url = {base_url} + relative_url
     return full_url


### PR DESCRIPTION
Update to handle storage object represented as json object rather than string. Also includes "/storage" in it already so we don't need to add it. Even though the client will change, you'll still want to have this.